### PR TITLE
Bump boxart dep, change package name, & set to private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
-  "name": "rwd-game-boiler",
+  "name": "boxart-boiler",
+  "private": true,
   "version": "0.0.0",
   "description": "",
   "author": "Bocoup, LLC",
   "license": "MIT",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/boxart/boxart-boiler.git"
+  },
   "scripts": {
     "build": "npm test && NODE_ENV=production webpack --config webpack.config.build.js",
     "lint": "grunt lint",
@@ -22,7 +27,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.1",
     "baggage-loader": "^0.2.4",
-    "boxart": "0.0.4",
+    "boxart": "0.0.5",
     "chai": "^3.4.1",
     "child-compiler-loader-list-webpack-plugin": "^0.1.0",
     "core-js": "^2.2.2",


### PR DESCRIPTION
- Update boxart dependency to pull in default animation transition bugfix
- Update package name to match repository
- This repository itself should not be `npm publish`ed, so we have set it to private in package.json
- Add repository field to package.json