### PR TITLE
Build infrastructure for live examples in documentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,5 +11,6 @@ module.exports = function(grunt) {
   grunt.registerTask('lint', ['eslint']);
   grunt.registerTask('test', ['lint', 'karma:ci']);
   grunt.registerTask('build', ['test', 'build-env', 'webpack:build']);
-  grunt.registerTask('docs', ['jekyll']);
+  grunt.registerTask('build-examples-dev', ['build-env', 'webpack:examples-dev']);
+  grunt.registerTask('docs', ['build-env', 'webpack:examples', 'jekyll']);
 };

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ The BoxArt-Boiler source contains a number of useful inline comments embedded wi
 ### Generate Docs
 `grunt docs` or `npm run docs`
 
-The `grunt docs` command (aliased to `npm run docs`) will use Jekyll to build the documentation from the [docs-src directory] into the `docs/` folder, and will then start a web server on http://localhost:4000/ : the documentation site can be viewed at this address, and the HTML documentation will automatically be re-generated if any of the source markdown files change. (Note however that this server does not include live reload, so you will need to manually refresh your browser window to see those changes.)
+The `grunt docs` command (aliased to `npm run docs`) will compile the live inline code example files, then use Jekyll to build the documentation site from the [docs-src directory] into the `docs/` folder. Once built, a web server will be available on http://localhost:4000/ : the documentation site can be viewed at this address, and the HTML documentation will automatically be re-generated if any of the source markdown files change. (Note however that this server does not include live reload, so you will need to manually refresh your browser window to see those changes.)
+
+### Developing Inline Examples
+`npm run docs-dev`
+
+Code for the live inline (iframed) examples within the documentation is contained within the `examples/` folder in the repository root. Running `npm run docs-dev` will start the Jekyll site as with `grunt docs`, but will start a webpack build _in parallel_ so that any changes to the examples source code will be compiled into the docs-src folder, and then picked up by the Jekyll watcher and rendered into the live docs site. This one command has the same effect as running `grunt jekyll` and `grunt build-examples-dev` in two separate terminals.
 
 ## Tech Stack and Tool Chain
 

--- a/docs-src/.gitignore
+++ b/docs-src/.gitignore
@@ -1,0 +1,3 @@
+# Do not include generated documentation examples in the build: they will
+# be compiled from `/examples/` when the `grunt docs` command is run
+examples/

--- a/docs-src/pages/about.md
+++ b/docs-src/pages/about.md
@@ -71,7 +71,12 @@ The BoxArt-Boiler source contains a number of useful inline comments embedded wi
 ### Generate Docs
 `grunt docs` or `npm run docs`
 
-The `grunt docs` command (aliased to `npm run docs`) will use Jekyll to build the documentation from the [docs-src directory] into the `docs/` folder, and will then start a web server on http://localhost:4000/ : the documentation site can be viewed at this address, and the HTML documentation will automatically be re-generated if any of the source markdown files change. (Note however that this server does not include live reload, so you will need to manually refresh your browser window to see those changes.)
+The `grunt docs` command (aliased to `npm run docs`) will compile the live inline code example files, then use Jekyll to build the documentation site from the [docs-src directory] into the `docs/` folder. Once built, a web server will be available on http://localhost:4000/ : the documentation site can be viewed at this address, and the HTML documentation will automatically be re-generated if any of the source markdown files change. (Note however that this server does not include live reload, so you will need to manually refresh your browser window to see those changes.)
+
+### Developing Inline Examples
+`npm run docs-dev`
+
+Code for the live inline (iframed) examples within the documentation is contained within the `examples/` folder in the repository root. Running `npm run docs-dev` will start the Jekyll site as with `grunt docs`, but will start a webpack build _in parallel_ so that any changes to the examples source code will be compiled into the docs-src folder, and then picked up by the Jekyll watcher and rendered into the live docs site. This one command has the same effect as running `grunt jekyll` and `grunt build-examples-dev` in two separate terminals.
 
 ## Tech Stack and Tool Chain
 

--- a/examples/animation-simple/index.jsx
+++ b/examples/animation-simple/index.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import {Animated, AnimatedAgent} from 'boxart';
+
+import Component from '../../src/modules/update-ancestor';
+
+import './index.styl';
+
+class Main extends Component {
+
+  constructor() {
+    super();
+
+    this.state = {
+      pos: 'left'
+    };
+  }
+
+  swap() {
+    this.setState({
+      pos: this.state.pos === 'left' ? 'right' : 'left'
+    });
+  }
+
+  render() {
+    var pos1, pos2;
+    var animatedContent = (
+      <Animated animateKey="h1">
+        <p><strong>Animated Content</strong></p>
+      </Animated>
+    );
+
+    if (this.state.pos === 'right') {
+      pos1 = animatedContent;
+    } else {
+      pos2 = animatedContent;
+    }
+
+    return (
+      <AnimatedAgent>
+        <div className="game-board">
+          <button type="button" onClick={this.swap}>Swap</button>
+          <div className="container" id="container1">
+            {pos1}
+          </div>
+          <div className="container" id="container2">
+            {pos2}
+          </div>
+        </div>
+      </AnimatedAgent>
+    );
+  }
+}
+
+// Boilerplate
+// ============================================================================
+
+import '../../src/styles/index.styl';
+import ReactDOM from 'react-dom';
+import FullViewport from '../../src/modules/full-viewport';
+import PreventZoom from '../../src/modules/prevent-zoom';
+
+class Example extends Component {
+  render() {
+    return (
+      <PreventZoom><FullViewport>
+        <Main />
+      </FullViewport></PreventZoom>
+    );
+  }
+}
+
+ReactDOM.render(
+  <Example />,
+  document.getElementById('root')
+);

--- a/examples/animation-simple/index.styl
+++ b/examples/animation-simple/index.styl
@@ -1,0 +1,9 @@
+button, .container {
+  display: inline-block;
+}
+.container {
+  border: 1px solid black;
+  height: 2em;
+  min-width: 300px;
+  margin: 5px 0;
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "docs": "grunt docs",
+    "docs-dev": "parallelshell 'grunt build-examples-dev' 'grunt jekyll'",
     "build": "grunt build",
     "lint": "grunt lint",
     "start": "grunt",
@@ -59,6 +60,7 @@
     "lolex": "^1.4.0",
     "mocha": "^2.3.4",
     "offline-plugin": "^2.0.2",
+    "parallelshell": "^2.0.0",
     "postcss-loader": "^0.8.0",
     "react": "^15.0.2",
     "react-addons-update": "^15.0.1",

--- a/tasks/grunt-webpack.js
+++ b/tasks/grunt-webpack.js
@@ -1,10 +1,40 @@
 'use strict';
 
+var webpack = require('webpack');
+
+var mainWebpackConfig = require('../webpack.config.build');
+var docsExamplesWebpackConfig = require('../webpack.config.docs-examples');
+
 module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-webpack');
 
   grunt.config.set('webpack', {
     build: require('../webpack.config.build'),
+    // grunt build-examples will build _and minify_ the documentation examples
+    // (should be part of gh-pages deploy process)
+    examples: Object.assign({}, docsExamplesWebpackConfig, {
+      plugins: docsExamplesWebpackConfig.plugins.concat(
+        // The grunt build-env task will cause Babel to exclude hmre code; to
+        // ensure the production version of React is used, we must also define
+        // NODE_ENV as production within the context of the webpack bundle.
+        new webpack.DefinePlugin({
+          'process.env': {
+            NODE_ENV: JSON.stringify('production'),
+          },
+        }),
+        // Minify
+        new webpack.optimize.DedupePlugin(),
+        new webpack.optimize.UglifyJsPlugin()
+      ),
+    }),
+    // grunt build-examples-dev will start a watcher to rebuild the
+    // examples in debug mode when their code changes, for development
+    'examples-dev': Object.assign({}, docsExamplesWebpackConfig, {
+      debug: true,
+      // Watch mode
+      watch: true,
+      keepalive: true,
+    }),
   });
 
   grunt.config.set('webpack-dev-server', {

--- a/webpack.config.docs-examples.js
+++ b/webpack.config.docs-examples.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var glob = require('glob');
+var path = require('path');
+var HtmlWepbackPlugin = require('html-webpack-plugin');
+
+// We have a number of example files, which should all be built into
+// individual HTML files so that they can be included in the docs as
+// discrete examples.
+var entryFiles = glob.sync('./examples/*/index.jsx').reduce(function(entry, filepath) {
+  var folderMatch = filepath.match(/[\/]([^\/]+)\/index.jsx/i);
+  // Folder name should always match something, but safeguard against issues
+  // with conditionals. Convert all non-(letters|numbers) in name to dashes.
+  // This will be the name of the generated HTML file that can be embedded
+  // in an <iframe> from the documentation site.
+  var foldername = folderMatch && folderMatch[1] && folderMatch[1].replace(/[^\w]/g, '-');
+  if (foldername) {
+    entry[foldername] = filepath;
+  }
+  return entry;
+}, {});
+
+var exportExampleHTML = Object.keys(entryFiles).map(function(chunk) {
+  return new HtmlWepbackPlugin({
+    chunks: [chunk],
+    filename: chunk + '.html',
+    template: './src/index.html',
+    inject: 'body',
+  });
+});
+
+module.exports = {
+  context: __dirname,
+  // Build one example HTML file for each example index.jsx
+  entry: entryFiles,
+  output: {
+    // Output into docs-src
+    path: path.join(__dirname, 'docs-src/examples'),
+    filename: '[name].js',
+  },
+  devtool: 'source-map',
+  // Same loaders and resolution rules as in the main build
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      },
+      // Autoload style files named like an included jsx file.
+      {
+        test: /\.jsx$/,
+        exclude: /node_modules/,
+        loader: 'baggage-loader?[file].styl',
+      },
+      {
+        test: /\.styl$/,
+        loader: 'style-loader!css-loader!postcss-loader!stylus-loader',
+      },
+      {
+        test: /\.(png|webm|svg)$/,
+        loader: 'file-loader',
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader',
+      },
+      {
+        test: /[/\\]soundjs/,
+        loader: 'exports-loader?createjs!script-loader',
+      },
+      {
+        test: /\.wav$/,
+        loader: 'file-loader',
+      },
+    ],
+  },
+  resolve: {
+    modulesDirectories: ['node_modules', 'vendor'],
+    extensions: ['', '.js', '.jsx', '.min.js'],
+  },
+  // Use an array of HtmlWebpackPlugin instances to handle building the HTML
+  // for each example
+  plugins: exportExampleHTML,
+};


### PR DESCRIPTION
@mzgoddard Running into some trouble here. I would think that running `grunt docs-dev` would keep the webpack server running; but it just completes once, and then exits. Any insight on what I might be doing wrong?

Steps to reproduce: pull this branch, run `grunt docs-dev`; observe that example files are generated, but that jekyll does not run.

Additionally I am not clear on how to get the rendered JS to be minified and compressed (we can't use the `-p` webpack CLI option from grunt), and I would like to build minified versions to maintain the performance of the docs site.