### PR TITLE
Add AnimatedPreview tool

### DIFF
--- a/tasks/grunt-eslint.js
+++ b/tasks/grunt-eslint.js
@@ -16,6 +16,12 @@ module.exports = function(grunt) {
       },
       src: ['examples/**/*.js{,x}'],
     },
+    tools: {
+      options: {
+        configFile: 'tools/.eslintrc',
+      },
+      src: ['tools/**/*.js{,x}'],
+    },
     tests: {
       options: {
         configFile: 'tests/.eslintrc',

--- a/tools/.eslintrc
+++ b/tools/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "../eslint/eslint-defaults.json",
+    "../eslint/eslint-jsx.json"
+  ],
+  "env": {
+    "browser": true
+  }
+}

--- a/tools/animated-preview/animated-clip-player.jsx
+++ b/tools/animated-preview/animated-clip-player.jsx
@@ -1,0 +1,67 @@
+import React, {Children} from 'react';
+
+import {Animated as Component} from 'boxart';
+
+import ClipPlayer from './clip-player';
+
+export default class AnimatedClipPlayer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.clipPlayer = null;
+    this.componentWillReceiveProps(this.props);
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (
+      typeof newProps.clipPlayer !== 'undefined' &&
+      this.clipPlayer !== newProps.clipPlayer
+    ) {
+      this.clipPlayer = newProps.clipPlayer;
+    }
+    if (!this.clipPlayer) {
+      this.clipPlayer = new ClipPlayer();
+    }
+  }
+
+  getAnimateKey() {
+    if (this.props.animateKey) {
+      return this.props.animateKey;
+    }
+    if (!this.animateKey) {
+      this.animateKey = Math.random().toString();
+    }
+    return this.animateKey;
+  }
+
+  animate(options) {
+    this.clipPlayer.setArmature(null);
+    this.clipPlayer.setClip(this.props.clip);
+    this.clipPlayer.setArmature(this.props.armature || this.child);
+    return this.clipPlayer.animate(options);
+  }
+
+  render() {
+    let child = Children.toArray(this.props.children)[0];
+    if (child) {
+      const original = child;
+      child = React.cloneElement(child, {key: child.key, ref: component => {
+        if (original.ref) {
+          original.ref(component);
+        }
+        this.child = component;
+      }});
+    }
+    else {
+      child = <span></span>;
+    }
+    return child;
+  }
+}
+
+AnimatedClipPlayer.propTypes = {
+  animateKey: React.PropTypes.any,
+  clip: React.PropTypes.object,
+  armature: React.PropTypes.object,
+  children: React.PropTypes.node,
+};

--- a/tools/animated-preview/armature-list.jsx
+++ b/tools/animated-preview/armature-list.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import Component from '../../src/modules/update-ancestor';
+
+import NavList from './nav-list';
+
+const armatures = require('./js-list')
+.map(function(exports) {
+  return exports.default || exports;
+})
+.filter(function(exports) {
+  return (
+    (
+      exports.prototype &&
+      exports.prototype.previewArmature === true &&
+      exports.previewArmature !== false
+    ) ||
+    exports.previewArmature === true
+  );
+});
+
+export default class ArmatureList extends Component {
+  handleItemSelected(arm) {
+    if (this.props.selectArmature) {
+      this.props.selectArmature(arm);
+    }
+  }
+
+  render() {
+    const {selected} = this.props;
+    return (<NavList title="Armatures" {...this.props}>
+      {armatures.map(arm => (
+        <div
+          key={arm.name || arm.prototype.armatureName || arm.armatureName}
+          onClick={() => this.handleItemSelected(arm)}
+          className={selected === arm ? 'nav-list-item-selected' : ''}>
+          {arm.name || arm.prototype.armatureName || arm.armatureName}
+        </div>
+      ))}
+    </NavList>);
+  }
+}
+
+ArmatureList.propTypes = {
+  selectArmature: React.PropTypes.func,
+  selected: React.PropTypes.func,
+};

--- a/tools/animated-preview/clip-list.jsx
+++ b/tools/animated-preview/clip-list.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import Component from '../../src/modules/update-ancestor';
+
+import NavList from './nav-list';
+
+import ClipPlayer from './clip-player';
+
+const clips = require('./js-list')
+.map(function(exports) {
+  return exports.default || exports;
+})
+.filter(function(exports) {
+  return ClipPlayer.isClip(exports);
+});
+
+export default class ClipList extends Component {
+  handleItemSelected(clip) {
+    if (this.props.selectClip) {
+      this.props.selectClip(clip);
+    }
+  }
+
+  render() {
+    const {selected} = this.props;
+    if (
+      selected &&
+      !clips.reduce((carry, clip) => carry || clip === selected, false)
+    ) {
+      Promise.resolve()
+      .then(() => this.handleItemSelected(clips.reduce((carry, clip) => {
+        return clip.metadata.name === selected.metadata.name ? clip : carry;
+      }, null)));
+    }
+    return (<NavList title="Clips" {...this.props}>
+      {clips.map(clip => (
+        <div
+          key={clip.metadata.name}
+          onClick={() => this.handleItemSelected(clip)}
+          className={selected === clip ? 'nav-list-item-selected' : ''}>
+          {clip.metadata.name}
+        </div>
+      ))}
+    </NavList>);
+  }
+}
+
+ClipList.propTypes = {
+  selectClip: React.PropTypes.func,
+  selected: React.PropTypes.object,
+};

--- a/tools/animated-preview/clip-player.js
+++ b/tools/animated-preview/clip-player.js
@@ -1,0 +1,285 @@
+export default class ClipPlayer {
+  constructor() {
+    this.armature = null;
+    this.clip = null;
+
+    this._replaced = null;
+    this._store = null;
+  }
+
+  setArmature(armature) {
+    this.armature = armature;
+  }
+
+  setClip(clip) {
+    this.clip = clip;
+  }
+
+  _replace() {
+    const wires = this._getWires();
+    if (!wires) {return;}
+
+    const wireProperties = this._getWireProperties();
+
+    this._replaced = {};
+    for (const wireKey in this.clip) {
+      if (wireKey === 'metadata') {continue;}
+      if (!wires[wireKey]) {continue;}
+
+      this._replaced[wireKey] = {};
+
+      const wireValue = this.clip[wireKey];
+      if (wireValue.styles) {
+        this._replaced[wireKey].styles = {};
+        for (const styleKey in wireValue.styles) {
+          this._replaced[wireKey].styles[styleKey] = wires[wireKey].style[styleKey];
+        }
+      }
+      if (wireValue.attributes) {
+        this._replaced[wireKey].attributes = {};
+        for (const attributeKey in wireValue.attributes) {
+          this._replaced[wireKey].attributes[attributeKey] = wires[wireKey].getAttribute(attributeKey);
+        }
+      }
+      if (wireValue.properties && wireProperties) {
+        this._replaced[wireKey].properties = {};
+        for (const propertyKey in wireValue.properties) {
+          if (!wireProperties[wireKey][propertyKey]) {continue;}
+          this._replaced[wireKey].properties[propertyKey] = wireProperties[wireKey][propertyKey](wires[wireKey]);
+        }
+      }
+    }
+  }
+
+  _primeStore(inputs, wires, wireProperties) {
+    if (!this._store) {
+      this._store = {};
+    }
+
+    for (const wireKey in this.clip) {
+      if (wireKey === 'metadata') {continue;}
+      if (!wires[wireKey]) {continue;}
+
+      this._store[wireKey] = this._store[wireKey] || {};
+
+      const wireValue = this.clip[wireKey];
+      if (wireValue.styles) {
+        this._store[wireKey].styles = this._store[wireKey].styles || {};
+        for (const styleKey in wireValue.styles) {
+          const _compiled = this._store[wireKey].styles[styleKey];
+          if (!_compiled || _compiled.inputs !== inputs) {
+            this._store[wireKey].styles[styleKey] = [];
+            this._store[wireKey].styles[styleKey].inputs = inputs;
+          }
+        }
+      }
+      if (wireValue.attributes) {
+        this._store[wireKey].attributes = this._store[wireKey].styles || {};
+        for (const attributeKey in wireValue.attributes) {
+          const _compiled = this._store[wireKey].attributes[attributeKey];
+          if (!_compiled || _compiled.inputs !== inputs) {
+            this._store[wireKey].attributes[attributeKey] = [];
+            this._store[wireKey].attributes[attributeKey].inputs = inputs;
+          }
+        }
+      }
+      if (wireValue.properties && wireProperties) {
+        this._store[wireKey].properties = this._store[wireKey].styles || {};
+        for (const propertyKey in wireValue.properties) {
+          if (!wireProperties[wireKey][propertyKey]) {continue;}
+          const _compiled = this._store[wireKey].properties[propertyKey];
+          if (!_compiled || _compiled.inputs !== inputs) {
+            this._store[wireKey].properties[propertyKey] = [];
+            this._store[wireKey].properties[propertyKey].inputs = inputs;
+          }
+        }
+      }
+    }
+  }
+
+  _restore() {
+    if (!this._replaced) {return;}
+
+    const wires = this._getWires();
+    if (!wires) {return;}
+
+    const wireProperties = this._getWireProperties();
+
+    for (const wireKey in this.clip) {
+      if (wireKey === 'metadata') {continue;}
+      if (!wires[wireKey]) {continue;}
+
+      const wireValue = this.clip[wireKey];
+      if (wireValue.styles) {
+        for (const styleKey in wireValue.styles) {
+          wires[wireKey].style[styleKey] = this._replaced[wireKey].styles[styleKey];
+        }
+      }
+      if (wireValue.attributes) {
+        for (const attributeKey in wireValue.attributes) {
+          wires[wireKey].setAttribute(attributeKey, this._replaced[wireKey].attributes[attributeKey]);
+        }
+      }
+      if (wireValue.properties && wireProperties) {
+        for (const propertyKey in wireValue.properties) {
+          if (!wireProperties[wireKey][propertyKey]) {continue;}
+          wireProperties[wireKey][propertyKey](wires[wireKey], this._replaced[wireKey].properties[propertyKey]);
+        }
+      }
+    }
+
+    this._replaced = null;
+  }
+
+  _step(t, inputs, wires, wireProperties) {
+    for (const wireKey in this.clip) {
+      if (wireKey === 'metadata') {continue;}
+      if (!wires[wireKey]) {continue;}
+
+      const wireValue = this.clip[wireKey];
+      const wireStore = this._store[wireKey];
+      if (wireValue.styles) {
+        for (const styleKey in wireValue.styles) {
+          const styleValue = wireValue.styles[styleKey];
+          const styleValueStore = wireStore.styles[styleKey];
+          wires[wireKey].style[styleKey] = this._stepValue(t, inputs, styleValue, styleValueStore);
+        }
+      }
+      if (wireValue.attributes) {
+        for (const attributeKey in wireValue.attributes) {
+          const attributeValue = wireValue.attributes[attributeKey];
+          const attributeValueStore = wireStore.attribute[attributeKey];
+          wires[wireKey].setAttribute(attributeKey, this._stepValue(t, inputs, attributeValue, attributeValueStore));
+        }
+      }
+      if (wireValue.properties && wireProperties) {
+        for (const propertyKey in wireValue.properties) {
+          if (!wireProperties[wireKey][propertyKey]) {continue;}
+          const propertyValue = wireValue.properties[propertyKey];
+          const propertyValueStore = wireStore.properties[propertyKey];
+          wireProperties[propertyKey](wires[wireKey], this._stepValue(t, inputs, propertyValue, propertyValueStore));
+        }
+      }
+    }
+  }
+
+  _stepValue(t, inputs, values, store) {
+    return this._stepValueArray(t, inputs, values, store);
+  }
+
+  _interpolate(a, b, t) {
+    if (typeof a === 'number') {
+      return (b - a) * t + a;
+    }
+    return a;
+  }
+
+  _compileNumber(a, b) {
+    return t => (b - a) * t + a;
+  }
+
+  _compile(a, b) {
+    if (typeof a === 'function') {
+      return a;
+    }
+    if (typeof a === 'number') {
+      return this._compileNumber(a, b);
+    }
+    return t => a;
+  }
+
+  _compileInputs(a, inputs) {
+    if (typeof a === 'function') {
+      const result = a(inputs);
+      if (typeof result === 'function') {
+        return result;
+      }
+    }
+    return a;
+  }
+
+  _compileArrayMember(values, i, inputs) {
+    const a = values[i + 1];
+
+    const minT = values[i];
+    const maxT = i < values.length - 2 ? values[i + 2] : this.clipDuration();
+    const duration = maxT - minT;
+
+    let bound;
+    if (typeof a === 'function') {
+      bound = this._compileInputs(a, inputs);
+    }
+    else if (i < values.length - 2) {
+      const boundB = this._compileInputs(values[i + 3], inputs);
+      const b = typeof boundB === 'function' ? b(0) : b;
+      bound = this._compile(a, b);
+    }
+    else {
+      bound = a;
+    }
+
+    if (typeof bound === 'function') {
+      return t => bound((t - minT) / duration);
+    }
+    return t => bound;
+  }
+
+  _stepValueArray(t, inputs, values, store) {
+    for (let i = values.length - 2; i >= 0; i -= 2) {
+      if (values[i] <= t) {
+        let member = store[i + 1];
+        if (!member) {
+          member = store[i + 1] = this._compileArrayMember(values, i, inputs);
+        }
+        return member(t);
+      }
+    }
+    return '';
+  }
+
+  _getWires() {
+    return this.armature && this.armature.getWires && this.armature.getWires();
+  }
+
+  _getWireInputs() {
+    return this.armature.getWireInputs && this.armature.getWireInputs();
+  }
+
+  _getWireProperties() {
+    return this.armature.getWireProperties && this.armature.getWireProperties();
+  }
+
+  animate(options) {
+    if (!this.armature || !this.clip) {return null;}
+
+    const wires = this._getWires();
+    if (!wires) {return null;}
+
+    const inputs = this._getWireInputs();
+    const wireProperties = this._getWireProperties();
+
+    this._replace();
+    this._primeStore(inputs);
+    const timer = options.timer();
+    timer.cancelable(() => this._restore());
+    const start = Date.now();
+    const clipDuration = this.clipDuration();
+    timer.loop(() => {
+      const now = Date.now();
+      const t = Math.min(now - start, clipDuration);
+      this._step(t, inputs, wires, wireProperties);
+      return t;
+    })
+    .then(() => this._restore());
+
+    return timer;
+  }
+
+  clipDuration() {
+    return this.clip.metadata.duration;
+  }
+}
+
+ClipPlayer.isClip = function(data) {
+  return data.metadata && data.metadata.duration;
+};

--- a/tools/animated-preview/clip-preview-player.js
+++ b/tools/animated-preview/clip-preview-player.js
@@ -1,0 +1,167 @@
+import ClipPlayer from './clip-player';
+
+export default class ClipPreviewPlayer extends ClipPlayer {
+  constructor() {
+    super();
+
+    this.listeners = [];
+
+    this.state = {
+      state: 'playing',
+      t: 0,
+      tNormalized: 0,
+    };
+
+    this._resume = null;
+
+    this.play = this.play.bind(this);
+    this.pause = this.pause.bind(this);
+    this.stepForward = this.stepForward.bind(this);
+    this.stepBackward = this.stepBackward.bind(this);
+  }
+
+  setArmature(armature) {
+    if (this.armature !== armature) {
+      this._restore();
+    }
+    this.armature = armature;
+    this._replace();
+    this.step(0);
+  }
+
+  setClip(clip) {
+    if (this.clip !== clip) {
+      this._restore();
+    }
+    this.clip = clip;
+    this._replace();
+    this.step(0);
+  }
+
+  play() {
+    this._update({
+      state: 'playing',
+    })
+    .then(this._resume);
+  }
+
+  pause() {
+    return this._update({
+      state: 'paused',
+    });
+  }
+
+  stepForward() {
+    this.pause()
+    .then(() => {
+      this.step(Math.min(this.state.t + 16, this.clipDuration()));
+    });
+  }
+
+  stepBackward() {
+    this.pause()
+    .then(() => {
+      this.step(Math.max(this.state.t - 16, 0));
+    });
+  }
+
+  step(t) {
+    if (!this.armature || !this.clip) {return;}
+
+    const wires = this._getWires();
+    if (!wires) {return;}
+
+    const inputs = this._getWireInputs();
+    const wireProperties = this._getWireProperties();
+
+    this._primeStore(inputs, wires, wireProperties);
+    this._step(t, inputs, wires, wireProperties);
+
+    const tNormalized = t / this.clipDuration();
+    this._update({
+      t,
+      tNormalized,
+    });
+  }
+
+  animate(options) {
+    if (!this.armature || !this.clip) {return null;}
+
+    const wires = this._getWires();
+    if (!wires) {return null;}
+
+    const inputs = this._getWireInputs();
+    const wireProperties = this._getWireProperties();
+
+    this._primeStore(inputs, wires, wireProperties);
+
+    const timer = options.timer();
+    const loop = () => {
+      let start = Date.now() - this.state.t;
+      const clipDuration = this.clipDuration();
+      timer.loop(() => {
+        if (this.state.state !== 'playing') {
+          return 1;
+        }
+
+        const now = Date.now();
+        let t = Math.min(now - start, clipDuration);
+        if (t >= clipDuration) {
+          start = now;
+          t = 0;
+        }
+        const tNormalized = t / clipDuration;
+        this._step(t, inputs, wires, wireProperties);
+        this._update({
+          t,
+          tNormalized,
+        });
+        return 0;
+      })
+      .then(() => {
+        return timer.join(
+          new Promise(resolve => {this._resume = resolve;})
+          .then(() => {this._resume = null;})
+        );
+      })
+      .then(loop);
+    };
+    loop();
+    return timer;
+  }
+
+  _update(_change) {
+    return Promise.resolve(_change)
+    .then(change => {
+      for (const key in this.state) {
+        if (!change.hasOwnProperty(key)) {
+          change[key] = this.state[key];
+        }
+      }
+      this.state = change;
+      this.emitChange();
+    });
+  }
+
+  emitChange() {
+    this.listeners.forEach(listener => listener());
+  }
+
+  addChangeListener(fn) {
+    const index = this.listeners.indexOf(fn);
+    if (index === -1) {
+      this.listeners.push(fn);
+    }
+  }
+
+  removeChangeListener(fn) {
+    const index = this.listeners.indexOf(fn);
+    if (index !== -1) {
+      this.listeners.splice(index, 1);
+    }
+  }
+}
+
+ClipPreviewPlayer.isClip = function(data) {
+  return data.metadata && data.metadata.duration;
+};

--- a/tools/animated-preview/example-armatures/box-center.jsx
+++ b/tools/animated-preview/example-armatures/box-center.jsx
@@ -1,0 +1,32 @@
+import React, {Component} from 'react';
+
+export default class BoxCenter extends Component {
+  getWires() {
+    return {box: this.refs.box};
+  }
+
+  getWireInputs() {
+    return {
+      offset: (
+        this.refs.parent.getBoundingClientRect().width -
+          this.refs.box.getBoundingClientRect().width
+      ),
+    };
+  }
+
+  getWireProperties() {
+    return {};
+  }
+
+  render() {
+    return (<div ref="parent" style={{width: '100%', height: '100%', transform: 'translate(50%, 50%)'}}>
+      <div style={{width: '33%', paddingBottom: '33%'}}>
+        <div style={{width: '100%', height: '100%', transform: 'translate(-50%, -50%)'}}>
+          <div ref="box" style={{width: '100%', paddingBottom: '100%', background: 'black'}}></div>
+        </div>
+      </div>
+    </div>);
+  }
+}
+
+BoxCenter.previewArmature = true;

--- a/tools/animated-preview/example-armatures/box.jsx
+++ b/tools/animated-preview/example-armatures/box.jsx
@@ -1,0 +1,29 @@
+import React, {Component} from 'react';
+
+export default class Box extends Component {
+  getWires() {
+    return {box: this.refs.box};
+  }
+
+  getWireInputs() {
+    return {
+      offset: (
+        this.refs.parent.getBoundingClientRect().width -
+          this.refs.box.getBoundingClientRect().width
+      ),
+    };
+  }
+
+  getWireProperties() {
+    return {};
+  }
+
+  render() {
+    return (<div ref="parent" style={{width: '100%', height: '100%'}}>
+      <div ref="box" style={{width: '33%', paddingBottom: '33%', background: 'black'}}></div>
+      <div ref="boxDestination" style={{position: 'absolute', right: 0, width: '33%', paddingBottom: '33%'}}></div>
+    </div>);
+  }
+}
+
+Box.previewArmature = true;

--- a/tools/animated-preview/example-clips/box-jump-in.js
+++ b/tools/animated-preview/example-clips/box-jump-in.js
@@ -1,0 +1,24 @@
+const createArc = (b, a) => {
+  const bb = Math.pow(b, 2);
+  const bbOverA = Math.sqrt(bb / a);
+  return t => Math.pow(t * (b + bbOverA) - bbOverA, 2) / bb;
+};
+
+const arc = createArc(Math.sqrt(0.75), 3 / 2);
+
+export default {
+  metadata: {
+    name: 'Box - Jump In',
+    duration: 1000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, t => `translate3d(0, ${arc(t) * 75 - 75}%, 0) scale(${t * t})`,
+      ],
+      transformOrigin: [
+        0, '50% 100% 0',
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-jump.js
+++ b/tools/animated-preview/example-clips/box-jump.js
@@ -1,0 +1,25 @@
+const sinHalfT = t => Math.sin(t * Math.PI);
+const sinQuarterT = t => Math.sin(t * Math.PI / 2);
+const launchT = t => -(t - 1) * (t - 1) + 1;
+
+export default {
+  metadata: {
+    name: 'Box - Jump',
+    duration: 3000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, t => `scale(${t * 0.1 + 1}, ${t * -0.1 + 1})`,
+        900, t => `scale(${t * -0.1 + 1.1}, ${t * 0.1 + 0.9})`,
+        1000, t => `translate(0, ${launchT(t) * -50}%) scale(1, ${sinHalfT(launchT(t)) * 0.1 + 1})`,
+        1500, t => `translate(0, ${(t * t) * 50 + -50}%) scale(1, ${sinHalfT(t * t) * 0.1 + 1})`,
+        2000, t => `scale(${sinQuarterT(t) * 0.1 + 1}, ${sinQuarterT(t) * -0.1 + 1})`,
+        2100, t => `scale(${t * -0.1 + 1.1}, ${t * 0.1 + 0.9})`,
+      ],
+      transformOrigin: [
+        0, '50% 100% 0',
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-rotate-in-drop.js
+++ b/tools/animated-preview/example-clips/box-rotate-in-drop.js
@@ -1,0 +1,21 @@
+export default {
+  metadata: {
+    name: 'Box - Rotate In Drop',
+    duration: 2000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, (t, inputs) => `rotate(${-t * 360}deg) scale(${t})`,
+        972, (t, inputs) => `rotate(${-t * 10}deg)`,
+        1000, (t, inputs) => `rotate(-10deg)`,
+        1500, (t, inputs) => `rotate(${-10 * (1 - t * t)}deg)`,
+      ],
+      transformOrigin: [
+        0, '50% 50% 0',
+        972, '50% 50% 0',
+        972, '0% 100% 0',
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-rotate-in.js
+++ b/tools/animated-preview/example-clips/box-rotate-in.js
@@ -1,0 +1,13 @@
+export default {
+  metadata: {
+    name: 'Box - Rotate In',
+    duration: 1000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, (t, inputs) => `rotate(${-t * 360}deg) scale(${t})`,
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-rotate-out.js
+++ b/tools/animated-preview/example-clips/box-rotate-out.js
@@ -1,0 +1,19 @@
+const pow2 = t => t * t;
+const invRotateHeight = t => Math.cos(Math.abs((t * Math.PI * 2 + Math.PI / 4) % (Math.PI / 2) - Math.PI / 4));
+
+export default {
+  metadata: {
+    name: 'Box - Rotate Out',
+    duration: 3000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, inputs => t => (
+          `translate(${inputs.offset * pow2(t)}px, 0)` +
+          `rotate(${t * 360}deg) scale(${invRotateHeight(t)})`
+        ),
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-shake-2.js
+++ b/tools/animated-preview/example-clips/box-shake-2.js
@@ -1,0 +1,18 @@
+const sin2T = t => Math.sin(t * Math.PI * 4);
+
+export default {
+  metadata: {
+    name: 'Box - Shake 2',
+    duration: 1000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, (t, inputs) => `rotateZ(${sin2T(t) * Math.PI / 6}rad)`,
+      ],
+      transformOrigin: [
+        0, '50% 80% 0',
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-shake.js
+++ b/tools/animated-preview/example-clips/box-shake.js
@@ -1,0 +1,18 @@
+const sinT = t => Math.sin(t * Math.PI * 2);
+
+export default {
+  metadata: {
+    name: 'Box - Shake',
+    duration: 1000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, (t, inputs) => `rotate3d(0, 0, 1, ${sinT(t) * Math.PI / 18}rad)`,
+      ],
+      transformOrigin: [
+        0, '50% 80% 0',
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-slide-out.js
+++ b/tools/animated-preview/example-clips/box-slide-out.js
@@ -1,0 +1,17 @@
+export default {
+  metadata: {
+    name: 'Box - Slide Out',
+    duration: 1000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, inputs => t => `translate3d(${inputs.offset * (t * t)}px, 0, 0) scale(${1 - t})`,
+      ],
+      opacity: [
+        0, 1,
+        1000, 0,
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/example-clips/box-squash.js
+++ b/tools/animated-preview/example-clips/box-squash.js
@@ -1,0 +1,20 @@
+const sweep = t => Math.log(1 + t) / Math.log(2);
+const xScale = t => Math.min(1 + sweep(t), 2 - sweep(t));
+const yScale = t => Math.max(1 - sweep(t), sweep(t));
+
+export default {
+  metadata: {
+    name: 'Box - Squash',
+    duration: 1000,
+  },
+  box: {
+    styles: {
+      transform: [
+        0, inputs => t => `translate3d(${inputs.offset * sweep(t)}px, 0, 0) scale(${xScale(t)}, ${yScale(t)})`,
+      ],
+      transformOrigin: [
+        0, '50% 100% 0',
+      ],
+    },
+  },
+};

--- a/tools/animated-preview/index.html
+++ b/tools/animated-preview/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>BoxArt Animated Preview</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/tools/animated-preview/index.jsx
+++ b/tools/animated-preview/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import {render} from 'react-dom';
+
+import Main from './main';
+
+render(<Main />, document.getElementById('root'));

--- a/tools/animated-preview/js-list.js
+++ b/tools/animated-preview/js-list.js
@@ -1,0 +1,23 @@
+module.exports = (() => {
+  // Use webpack's context feature to load all of the js files in src and tools.
+  // `context`'s arguments are the path to load, a boolean for whether to load
+  // recursively or not, and a regex to filter by. Its statically analyzed by
+  // webpack so we cannot store the regex and reuse it. The literal regex needs
+  // to be passed.
+  //
+  // We need to make sure not to require entry points. Its not possible to
+  // reason that in a normal js file. This may need to become a loader. Avoiding
+  // that addition of complexity we can opt to exclude index files since they
+  // are the entry into a folder. This does mean making armatures as the index
+  // of a folder would be invisible to the preview tool. If a project can make
+  // more specific assumptions it should do so to reopen that oppurtunity, like
+  // how animated-preview excludes its root folder.
+  const srcContext = require.context(
+    '../../src', true,
+    /(^(?!.*(index|animated-preview)).*\.jsx?$)|(animated-preview\/[^\\]*\/.*\.jsx?$)/);
+  const toolsContext = require.context(
+    '..', true,
+    /(^(?!.*(index|animated-preview)).*\.jsx?$)|(animated-preview\/[^\\]*\/.*\.jsx?$)/);
+  return srcContext.keys().map(key => srcContext(key))
+  .concat(toolsContext.keys().map(key => toolsContext(key)));
+})();

--- a/tools/animated-preview/main.jsx
+++ b/tools/animated-preview/main.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import Component from '../../src/modules/update-ancestor';
+
+import ArmatureList from './armature-list';
+import ClipList from './clip-list';
+import ClipPreviewPlayer from './clip-preview-player';
+import PreviewControls from './preview-controls';
+import Preview from './preview';
+
+export default class Main extends Component {
+  constructor(props) {
+    super(props);
+    this.clipPlayer = new ClipPreviewPlayer();
+    this.state = {
+      ux: {
+        expandArmatures: false,
+        expandClips: false,
+      },
+    };
+  }
+
+  expandArmatures() {
+    this.updateState({ux: {expandArmatures: {$apply: expanded => !expanded}}});
+  }
+
+  selectArmature(_arm) {
+    const arm = _arm === this.state.ux.armature ? null : _arm;
+    this.updateState({ux: {armature: {$set: arm}}});
+  }
+
+  expandClips() {
+    this.updateState({ux: {expandClips: {$apply: expanded => !expanded}}});
+  }
+
+  selectClip(_clip) {
+    const clip = _clip === this.state.ux.clip ? null : _clip;
+    this.updateState({ux: {clip: {$set: clip}}});
+  }
+
+  render() {
+    return (<div className="main">
+      <ArmatureList shouldExpand={this.expandArmatures}
+        expand={this.state.ux.expandArmatures} selected={this.state.ux.armature}
+        selectArmature={this.selectArmature}/>
+      <ClipList shouldExpand={this.expandClips}
+        expand={this.state.ux.expandClips} selected={this.state.ux.clip}
+        selectClip={this.selectClip}/>
+      <div className="preview-col">
+        <PreviewControls clip={this.state.ux.clip} player={this.clipPlayer}/>
+        <Preview armature={this.state.ux.armature} clip={this.state.ux.clip}
+          player={this.clipPlayer}/>
+      </div>
+    </div>);
+  }
+}

--- a/tools/animated-preview/main.styl
+++ b/tools/animated-preview/main.styl
@@ -1,0 +1,72 @@
+html, body, #root {
+  height: 100%;
+  margin: 0;
+  font-family: Verdana, arial;
+}
+
+.main {
+  background: gray;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+
+.nav-col {
+  background: gray;
+  display: flex;
+  flex-direction: column;
+  float: left;
+  height: 100%;
+  width: 25%;
+}
+
+.nav-list {
+  background: gray;
+  // float: left;
+  // height: 50%;
+  width: 25%;
+}
+
+.nav-list-expand {
+  // height: 50%;
+}
+
+.preview-col {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: gray;
+  display: flex;
+  flex-direction: column;
+  float: right;
+  height: 100%;
+  width: 75%;
+}
+
+@media (max-width: 60em) {
+  .main {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-height: 100%;
+  }
+
+  .nav-list {
+    // display: flex;
+    // flex: 1 0 auto;
+    // flex: 0 0 auto;
+    // flex: 0 1 auto;
+    // float: initial;
+    height: auto;
+    width: 100%;
+  }
+
+  .preview-col {
+    position: relative;
+    flex: 1 1 auto;
+    float: initial;
+    height: auto;
+    width: 100%;
+  }
+}

--- a/tools/animated-preview/nav-list.jsx
+++ b/tools/animated-preview/nav-list.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import Component from '../../src/modules/update-ancestor';
+
+export default class NavList extends Component {
+  handleHeaderClick() {
+    if (this.props.shouldExpand) {
+      this.props.shouldExpand();
+    }
+  }
+
+  render() {
+    return (<div className={`nav-list ${this.props.expand ? 'nav-list-expand' : ''}`}>
+      <div className="nav-list-header" onClick={this.handleHeaderClick}>{this.props.title}</div>
+      <div className={`nav-list-content ${this.props.expand ? 'nav-list-content-expand' : ''}`}>
+        {this.props.children}
+      </div>
+    </div>);
+  }
+}
+
+NavList.propTypes = {
+  children: React.PropTypes.node,
+  expand: React.PropTypes.bool,
+  shouldExpand: React.PropTypes.func,
+  title: React.PropTypes.string,
+};

--- a/tools/animated-preview/nav-list.styl
+++ b/tools/animated-preview/nav-list.styl
@@ -1,0 +1,44 @@
+.nav-list {
+  flex: 0 0 auto;
+  // flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-list-expand {
+  flex: 1 1 auto;
+}
+
+.nav-list-header {
+  cursor: pointer;
+  flex: 0 0 auto;
+  background: darken(gray, 20%);
+  font-size: 1.5em;
+  padding: 0.75em;
+}
+
+.nav-list-content {
+  background: lighten(gray, 20%);
+  flex: 0 0 auto;
+  height: 0;
+  overflow: scroll;
+  transition: all 0.3s;
+}
+
+.nav-list-content-expand {
+  flex: 1 1 auto;
+  height: calc(50% - 3em);
+  height: 100px;
+}
+
+.nav-list-item {
+  background: lighten(gray, 50%);
+}
+
+.nav-list-item:nth-child(2n) {
+  background: lighten(gray, 30%);
+}
+
+.nav-list-item-selected {
+  background: white;
+}

--- a/tools/animated-preview/preview-controls.jsx
+++ b/tools/animated-preview/preview-controls.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import Component from '../../src/modules/update-ancestor';
+
+class PreviewButtons extends Component {
+  shouldComponentUpdate(newProps, newState) {
+    return this.props.state !== newProps.state;
+  }
+
+  buttonClass(name, active) {
+    return `preview-controls-${name}` + (
+      active ? ` preview-controls-${name}-active` : ''
+    );
+  }
+
+  render() {
+    const {player, state} = this.props;
+    return (<span>
+      <span onClick={player.play}
+        className={this.buttonClass('play', state === 'playing')}>Play</span>
+      <span onClick={player.pause}
+        className={this.buttonClass('pause', state === 'paused')}>Pause</span>
+      <span onClick={player.stepBackward}
+        className={'preview-controls-backward'}>Back</span>
+      <span onClick={player.stepForward}
+        className={'preview-controls-forward'}>Forward</span>
+    </span>);
+  }
+}
+
+PreviewButtons.propTypes = {
+  player: React.PropTypes.object,
+  state: React.PropTypes.string,
+};
+
+class PreviewTime extends Component {
+  shouldComponentUpdate(newProps, newState) {
+    return this.props.time !== newProps.time;
+  }
+
+  render() {
+    return (<div style={{
+      display: 'inline-block',
+      transform: 'translateZ(0)',
+    }}>{this.props.time}</div>);
+  }
+}
+
+PreviewTime.propTypes = {
+  time: React.PropTypes.number,
+};
+
+export default class PreviewControls extends Component {
+  constructor(props) {
+    super(props);
+    this.componentWillReceiveProps(props);
+    this.state = {
+      player: props.player && props.player.state || {},
+    };
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (this.props.player) {
+      this.props.player.removeChangeListener(this.handleClipPlayerChange);
+    }
+    if (newProps.player) {
+      newProps.player.addChangeListener(this.handleClipPlayerChange);
+    }
+  }
+
+  handleClipPlayerChange() {
+    this.setState({
+      player: this.props.player.state,
+    });
+  }
+
+  render() {
+    return (<div className="preview-controls">
+      <PreviewButtons state={this.state.player.state}
+        player={this.props.player} />
+      <PreviewTime time={this.state.player.t} />
+    </div>);
+  }
+}
+
+PreviewControls.propTypes = {
+  player: React.PropTypes.object,
+};

--- a/tools/animated-preview/preview-controls.styl
+++ b/tools/animated-preview/preview-controls.styl
@@ -1,0 +1,22 @@
+.preview-controls {
+  background: darken(gray, 20%);
+  flex: 0 0 auto;
+  font-size: 1.5em;
+  padding: 0.75em;
+  user-select: none;
+}
+
+.preview-controls-play,
+.preview-controls-pause,
+.preview-controls-forward,
+.preview-controls-backward {
+  cursor: pointer;
+}
+
+.preview-controls-play-active {
+  color: white;
+}
+
+.preview-controls-pause-active {
+  color: white;
+}

--- a/tools/animated-preview/preview.jsx
+++ b/tools/animated-preview/preview.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import {AnimatedAgent} from 'boxart';
+
+import Component from '../../src/modules/update-ancestor';
+
+import AnimatedClipPlayer from './animated-clip-player';
+
+export default class Preview extends Component {
+  render() {
+    const Armature = this.props.armature || 'span';
+    return (<AnimatedAgent>
+      <div className="preview">
+        <div className="preview-sub">
+          <AnimatedClipPlayer clip={this.props.clip}
+            clipPlayer={this.props.player}>
+            <Armature key={this.props.clip && this.props.clip.metadata.name} />
+          </AnimatedClipPlayer>
+        </div>
+      </div>
+    </AnimatedAgent>);
+  }
+}
+
+Preview.propTypes = {
+  armature: React.PropTypes.func,
+  clip: React.PropTypes.object,
+  player: React.PropTypes.object,
+};

--- a/tools/animated-preview/preview.styl
+++ b/tools/animated-preview/preview.styl
@@ -1,0 +1,16 @@
+.preview {
+  position: relative;
+  background: lighten(gray, 20%);
+  flex: 1 1 auto;
+  width: 100%;
+  height: 300px;
+}
+
+.preview-sub {
+  position: absolute;
+  overflow: scroll;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}

--- a/web_loaders/sub-json-loader.js
+++ b/web_loaders/sub-json-loader.js
@@ -1,6 +1,7 @@
 var loaderUtils = require('loader-utils');
 
 module.exports = function(content) {
+  this.cacheable && this.cacheable();
   var query = loaderUtils.parseQuery(this.query);
   var key = Object.keys(query)[0];
   console.log(key, JSON.parse(content)[key]);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,10 +7,11 @@ module.exports = {
   context: __dirname,
   entry: {
     main: './src',
+    'animated-preview': './tools/animated-preview',
   },
   output: {
     path: 'dist',
-    filename: '[hash].js',
+    filename: '[name].js',
   },
   devtool: 'source-map',
   module: {
@@ -60,6 +61,13 @@ module.exports = {
       filename: 'index.html',
       template: './src/index.html',
       inject: 'body',
+      chunks: ['main'],
+    }),
+    new HtmlWepbackPlugin({
+      filename: 'animated-preview.html',
+      template: './tools/animated-preview/index.html',
+      inject: 'body',
+      chunks: ['animated-preview'],
     }),
   ],
 };


### PR DESCRIPTION
- Lint tools
- Switch dev build to name files [name] instead of [hash]. With just
  [hash] the two output js files were colliding.

AnimatedPreview adds the concepts of armatures and clips to animate
them. Armatures are DOM hierarchies (that can be maintained by React)
with named elements that animation clips animate. As of this changeset
AnimatedPreview holds ClipPlayer and ClipPreviewPlayer (a subclass used
in AnimatedPreview). These classes will shortly go upstream to BoxArt.

Closes #86