### PR TITLE
Bump stylus-loader to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "style-loader": "^0.13.0",
-    "stylus-loader": "^1.5.1",
+    "stylus": "^0.54.5",
+    "stylus-loader": "^2.1.2",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.1"
   }


### PR DESCRIPTION
Node 6 changed its path handling subtly that doesn't work with
stylus-loader 1.X. 2.X works and doesn't impact older Node versions.
